### PR TITLE
fix: set initial warranty date to null

### DIFF
--- a/src/features/it/assets/components/asset-form.tsx
+++ b/src/features/it/assets/components/asset-form.tsx
@@ -57,7 +57,7 @@ export function AssetForm({
         purchaseDate: dateFormat(new Date()),
         purchaseCost: 0,
         vendorId: '',
-        warrantyExpiryDate: '',
+        warrantyExpiryDate: null,
         status: 'in_stock',
         condition: 'new',
         departmentId: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the warranty expiry date field initialization in the asset form to properly handle null values, improving data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->