### PR TITLE
feat(it): add Expenses & Budgeting dashboard with financial-year period filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "lint:check": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "test": "vitest run",
     "inngest": "pnpm dlx inngest-cli@latest dev -u http://localhost:3000/api/inngest",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -122,6 +123,7 @@
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(vite@8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
 
@@ -620,14 +623,23 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -1378,6 +1390,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@15.5.9':
     resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
 
@@ -1930,6 +1948,9 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.16.2':
     resolution: {integrity: sha512-lVJbvydLQIDZHKUb6Zs9Rq80QVTQ9xdCQE30eC9/cjg4wsMoEOg65QZPymUAIVJotpUAWJD0XYcwE7ugfxx5kQ==}
@@ -3037,6 +3058,104 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -3241,6 +3360,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/africastalking@0.6.2':
     resolution: {integrity: sha512-9SUZyQEQVUw8ww7Wc24r+pi9OvBHOzWU+/yEdQV0opfaYN9sNb6gVK1ugMxIlBlGGEnTzlCx8roqjL9I3Bbxvw==}
 
@@ -3249,6 +3371,9 @@ packages:
 
   '@types/bunyan@1.8.11':
     resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -3282,6 +3407,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -3541,6 +3669,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -3646,6 +3803,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -3769,6 +3930,10 @@ packages:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chainsaw@0.1.0:
     resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
@@ -3820,6 +3985,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
@@ -4135,6 +4303,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -4301,6 +4472,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -4311,6 +4485,10 @@ packages:
   exceljs@4.4.0:
     resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
     engines: {node: '>=8.3.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   export-to-csv@1.4.0:
     resolution: {integrity: sha512-6CX17Cu+rC2Fi2CyZ4CkgVG3hLl6BFsdAxfXiZkmDFIDY4mRx2y2spdeH6dqPHI9rP+AsHEfGeKz84Uuw7+Pmg==}
@@ -4867,8 +5045,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -4879,8 +5069,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -4891,8 +5093,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -4905,8 +5120,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -4919,8 +5148,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -4931,8 +5173,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   listenercount@1.0.1:
@@ -5087,6 +5339,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.9:
     resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
     engines: {node: ^18 || >=20}
@@ -5197,6 +5454,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -5246,6 +5507,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -5298,6 +5562,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -5307,6 +5575,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -5553,6 +5825,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5643,6 +5920,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   smol-toml@1.6.0:
     resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
     engines: {node: '>= 18'}
@@ -5671,12 +5951,18 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackblur-canvas@2.7.0:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
     engines: {node: '>=0.1.14'}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -5798,9 +6084,24 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
@@ -5955,6 +6256,90 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -5984,6 +6369,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -6285,9 +6675,20 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -6297,6 +6698,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6798,6 +7204,13 @@ snapshots:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@next/env@15.5.9': {}
@@ -7538,6 +7951,8 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+
+  '@oxc-project/types@0.139.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.16.2':
     optional: true
@@ -8571,6 +8986,57 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
@@ -8738,6 +9204,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/africastalking@0.6.2': {}
 
   '@types/aws-lambda@8.10.159': {}
@@ -8745,6 +9216,11 @@ snapshots:
   '@types/bunyan@1.8.11':
     dependencies:
       '@types/node': 20.19.27
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/connect@3.4.38':
     dependencies:
@@ -8777,6 +9253,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -9045,6 +9523,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -9211,6 +9730,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -9332,6 +9853,8 @@ snapshots:
       svg-pathdata: 6.0.3
     optional: true
 
+  chai@6.2.2: {}
+
   chainsaw@0.1.0:
     dependencies:
       traverse: 0.3.9
@@ -9389,6 +9912,8 @@ snapshots:
       readable-stream: 3.6.2
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   copy-anything@4.0.5:
     dependencies:
@@ -9678,6 +10203,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -9999,6 +10526,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
@@ -10014,6 +10545,8 @@ snapshots:
       tmp: 0.2.7
       unzipper: 0.10.14
       uuid: 8.3.2
+
+  expect-type@1.4.0: {}
 
   export-to-csv@1.4.0: {}
 
@@ -10067,6 +10600,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fflate@0.8.2: {}
 
@@ -10621,34 +11158,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -10666,6 +11236,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   listenercount@1.0.1: {}
 
@@ -10781,6 +11367,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.16: {}
+
   nanoid@5.1.9: {}
 
   napi-postinstall@0.3.4: {}
@@ -10874,6 +11462,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.3: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -10945,6 +11535,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
   peberminta@0.9.0: {}
 
   performance-now@2.1.0:
@@ -10991,6 +11583,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postal-mime@2.7.4: {}
@@ -10998,6 +11592,12 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11319,6 +11919,27 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -11454,6 +12075,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   smol-toml@1.6.0: {}
 
   sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
@@ -11474,6 +12097,8 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   stackblur-canvas@2.7.0:
     optional: true
 
@@ -11481,6 +12106,8 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -11623,10 +12250,21 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   tmp@0.2.7: {}
 
@@ -11826,6 +12464,48 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.27
+      esbuild: 0.25.12
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(vite@8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@20.19.27)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.19.27
+    transitivePeerDependencies:
+      - msw
+
   walk-up-path@4.0.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -11879,6 +12559,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/(protected)/it/expenses-budgeting/page.tsx
+++ b/src/app/(protected)/it/expenses-budgeting/page.tsx
@@ -1,41 +1,125 @@
-import type { Metadata } from 'next';
+import type { Metadata } from "next";
 
-import { HandCoinsIcon, WalletIcon } from 'lucide-react';
-import Link from 'next/link';
+import { PlusIcon } from "lucide-react";
+import Link from "next/link";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 
-import PageHeader from '@/components/custom/page-header';
-import { buttonVariants } from '@/components/ui/button';
-import { requireAnyPermission } from '@/lib/permissions/guards';
+import { ErrorFallback } from "@/components/custom/error-components";
+import PageHeader from "@/components/custom/page-header";
+import { buttonVariants } from "@/components/ui/button";
+import { BudgetTracker } from "@/features/it/components/dashboard/budget-tracker";
+import { CategoryBreakdown } from "@/features/it/components/dashboard/category-breakdown";
+import { DashboardSkeleton } from "@/features/it/components/dashboard/dashboard-skeleton";
+import { KpiCards } from "@/features/it/components/dashboard/kpi-cards";
+import { MonthlyOverviewChart } from "@/features/it/components/dashboard/monthly-overview-chart";
+import { PeriodSelect } from "@/features/it/components/dashboard/period-select";
+import { RecentExpenses } from "@/features/it/components/dashboard/recent-expenses";
+import {
+  buildDashboardKpis,
+  getCategoryRollup,
+  getMonthlyOverview,
+  getRecentExpenses,
+  getTotalSpent,
+} from "@/features/it/services/dashboard/data";
+import {
+  DASHBOARD_PERIOD_LABELS,
+  type DashboardPeriod,
+  DEFAULT_DASHBOARD_PERIOD,
+  getDashboardComparisonPeriodRange,
+  getDashboardPeriodRange,
+  isDashboardPeriod,
+} from "@/lib/helpers/dates";
+import { requireAnyPermission } from "@/lib/permissions/guards";
+import { ErrorBoundaryWithSuspense } from "@/components/custom/error-boundary-with-suspense";
 
 export const metadata: Metadata = {
-  title: 'IT Expenses & Budgeting',
+  title: "IT Expenses & Budgeting",
 };
 
-export default async function ITExpensesBudgetingPage() {
-  await requireAnyPermission(['it:admin', 'it:standard'], { mode: 'page' });
+type SearchParams = Promise<{ period?: string }>;
+
+export default async function ITExpensesBudgetingPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  await requireAnyPermission(["it:admin", "it:standard"], { mode: "page" });
+
+  const { period: periodParam } = await searchParams;
+  const period: DashboardPeriod =
+    periodParam && isDashboardPeriod(periodParam)
+      ? periodParam
+      : DEFAULT_DASHBOARD_PERIOD;
 
   return (
-    <PageHeader
-      title="IT Expenses & Budgeting"
-      description="Manage IT department expenses and budgets"
-      content={
-        <div className="flex gap-4 items-center">
-          <Link
-            href="/it/expenses-budgeting/budgets"
-            className={buttonVariants({ variant: 'tertiary' })}
-          >
-            <WalletIcon />
-            Manage Budgets
-          </Link>
-          <Link
-            href="/it/expenses-budgeting/expenses"
-            className={buttonVariants({ variant: 'pdfExport' })}
-          >
-            <HandCoinsIcon />
-            Manage Expenses
-          </Link>
+    <div className="space-y-6">
+      <PageHeader
+        title="Dashboard"
+        description={DASHBOARD_PERIOD_LABELS[period]}
+        content={
+          <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+            <PeriodSelect />
+            <Link
+              href="/it/expenses-budgeting/expenses/new"
+              className={buttonVariants({ variant: "default" })}
+            >
+              <PlusIcon />
+              Add Expense
+            </Link>
+          </div>
+        }
+      />
+      <ErrorBoundaryWithSuspense loader={<DashboardSkeleton />}>
+        <DashboardContent period={period} />
+      </ErrorBoundaryWithSuspense>
+    </div>
+  );
+}
+
+async function DashboardContent({ period }: { period: DashboardPeriod }) {
+  const referenceDate = new Date();
+  const range = getDashboardPeriodRange(period, referenceDate);
+  const comparisonRange = getDashboardComparisonPeriodRange(
+    period,
+    referenceDate,
+  );
+
+  const [
+    categoryRollup,
+    comparisonTotalSpent,
+    monthlyOverview,
+    recentExpenses,
+  ] = await Promise.all([
+    getCategoryRollup(range),
+    getTotalSpent(comparisonRange),
+    getMonthlyOverview(range, period, referenceDate),
+    getRecentExpenses(range),
+  ]);
+
+  const kpis = buildDashboardKpis(
+    categoryRollup,
+    range.monthsInPeriod,
+    comparisonTotalSpent,
+    comparisonRange.monthsInPeriod,
+  );
+
+  return (
+    <div className="space-y-6">
+      <KpiCards kpis={kpis} />
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <div className="xl:col-span-2">
+          <MonthlyOverviewChart data={monthlyOverview} />
         </div>
-      }
-    />
+        <CategoryBreakdown
+          categories={categoryRollup}
+          periodLabel={DASHBOARD_PERIOD_LABELS[period]}
+        />
+      </div>
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <RecentExpenses expenses={recentExpenses} />
+        <BudgetTracker categories={categoryRollup} />
+      </div>
+    </div>
   );
 }

--- a/src/features/it/components/dashboard/budget-tracker.tsx
+++ b/src/features/it/components/dashboard/budget-tracker.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty';
+import { type CategoryRollupRow } from '@/features/it/services/dashboard/data';
+import { getCategoryColor } from '@/features/it/utils/dashboard/colors';
+import { numberFormat } from '@/lib/helpers/formatters';
+import { cn } from '@/lib/utils';
+
+/**
+ * Category-level only, per the dashboard spec: no sub-category rows or
+ * expandable trees, even though the Banani reference shows sub-category
+ * breakdowns underneath each category.
+ */
+export function BudgetTracker({
+  categories,
+}: {
+  categories: Array<CategoryRollupRow>;
+}) {
+  return (
+    <Card className="shadow-none">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Budget Tracker</CardTitle>
+        <Link
+          href="/it/expenses-budgeting/budgets"
+          className="text-sm text-primary hover:underline"
+        >
+          View all
+        </Link>
+      </CardHeader>
+      <CardContent>
+        {categories.length === 0 ? (
+          <EmptyState
+            title="No categories yet"
+            description="Categories will appear here once they're created."
+            variant="default"
+          />
+        ) : (
+          <ul className="space-y-5">
+            {categories.map(row => {
+              const isOver = row.actual > row.budgeted;
+              const progressPct =
+                row.budgeted > 0
+                  ? Math.min((row.actual / row.budgeted) * 100, 100)
+                  : row.actual > 0
+                    ? 100
+                    : 0;
+              const color = getCategoryColor(row.colorIndex);
+
+              return (
+                <li key={row.categoryId} className="space-y-1.5">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2 font-medium">
+                      {row.categoryName}
+                      {isOver && (
+                        <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                          Over
+                        </span>
+                      )}
+                    </span>
+                    <span>
+                      <span
+                        className={cn(
+                          'font-medium',
+                          isOver && 'text-destructive',
+                        )}
+                      >
+                        {numberFormat(row.actual)}
+                      </span>{' '}
+                      <span className="text-muted-foreground">
+                        / {numberFormat(row.budgeted)}
+                      </span>
+                    </span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${progressPct}%`,
+                        backgroundColor: isOver
+                          ? 'var(--destructive)'
+                          : color,
+                      }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/it/components/dashboard/category-breakdown.tsx
+++ b/src/features/it/components/dashboard/category-breakdown.tsx
@@ -1,0 +1,85 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty';
+import { type CategoryRollupRow } from '@/features/it/services/dashboard/data';
+import { getCategoryColor } from '@/features/it/utils/dashboard/colors';
+import { numberFormat } from '@/lib/helpers/formatters';
+
+export function CategoryBreakdown({
+  categories,
+  periodLabel,
+}: {
+  categories: Array<CategoryRollupRow>;
+  periodLabel: string;
+}) {
+  const totalActual = categories.reduce((sum, row) => sum + row.actual, 0);
+  const sorted = [...categories].sort((a, b) => b.actual - a.actual);
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>By Category</CardTitle>
+        <p className="text-sm text-muted-foreground">{periodLabel}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {totalActual === 0 ? (
+          <EmptyState
+            title="No expenses in this period"
+            description="Category spending will appear here once expenses are recorded."
+            variant="default"
+          />
+        ) : (
+          <>
+            <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted">
+              {sorted.map(row => {
+                const percentage =
+                  totalActual > 0 ? (row.actual / totalActual) * 100 : 0;
+                if (percentage === 0) return null;
+                return (
+                  <div
+                    key={row.categoryId}
+                    style={{
+                      width: `${percentage}%`,
+                      backgroundColor: getCategoryColor(row.colorIndex),
+                    }}
+                  />
+                );
+              })}
+            </div>
+            <ul className="space-y-3">
+              {sorted.map(row => {
+                const percentage =
+                  totalActual > 0
+                    ? Math.round((row.actual / totalActual) * 100)
+                    : 0;
+                return (
+                  <li
+                    key={row.categoryId}
+                    className="flex items-center justify-between text-sm"
+                  >
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="size-2.5 rounded-full"
+                        style={{
+                          backgroundColor: getCategoryColor(row.colorIndex),
+                        }}
+                      />
+                      {row.categoryName}
+                    </span>
+                    <span className="flex items-center gap-3">
+                      <span className="text-muted-foreground">
+                        {percentage}%
+                      </span>
+                      <span className="font-medium">
+                        {numberFormat(row.actual)}
+                      </span>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/it/components/dashboard/dashboard-skeleton.tsx
+++ b/src/features/it/components/dashboard/dashboard-skeleton.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card key={index} className="shadow-none">
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="size-4" />
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-7 w-28" />
+              <Skeleton className="h-3 w-32" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <Card className="xl:col-span-2 shadow-none">
+          <CardHeader>
+            <Skeleton className="h-5 w-40" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-[320px] w-full" />
+          </CardContent>
+        </Card>
+        <Card className="shadow-none">
+          <CardHeader>
+            <Skeleton className="h-5 w-28" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-2.5 w-full rounded-full" />
+            {Array.from({ length: 5 }).map((_, index) => (
+              <Skeleton key={index} className="h-5 w-full" />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <Card key={index} className="shadow-none">
+            <CardHeader>
+              <Skeleton className="h-5 w-36" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {Array.from({ length: 5 }).map((__, rowIndex) => (
+                <Skeleton key={rowIndex} className="h-10 w-full" />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/it/components/dashboard/kpi-cards.tsx
+++ b/src/features/it/components/dashboard/kpi-cards.tsx
@@ -1,0 +1,131 @@
+import {
+  CalendarIcon,
+  CreditCardIcon,
+  TriangleAlertIcon,
+  WalletIcon,
+} from 'lucide-react';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { type DashboardKpis } from '@/features/it/services/dashboard/data';
+import { numberFormat } from '@/lib/helpers/formatters';
+import { cn } from '@/lib/utils';
+
+function formatDelta(deltaPct: number | null) {
+  if (deltaPct === null) return null;
+  const rounded = Math.round(deltaPct);
+  const sign = rounded > 0 ? '+' : '';
+  return `${sign}${rounded}%`;
+}
+
+function DeltaLine({
+  deltaPct,
+  context,
+}: {
+  deltaPct: number | null;
+  context: string;
+}) {
+  if (deltaPct === null) {
+    return <p className="text-xs text-muted-foreground">{context}</p>;
+  }
+
+  const isIncrease = deltaPct > 0;
+
+  return (
+    <p className="text-xs text-muted-foreground">
+      <span
+        className={cn(
+          'font-medium',
+          isIncrease ? 'text-destructive' : 'text-emerald-600',
+        )}
+      >
+        {formatDelta(deltaPct)}
+      </span>{' '}
+      {context}
+    </p>
+  );
+}
+
+export function KpiCards({ kpis }: { kpis: DashboardKpis }) {
+  const worstOverBudget = kpis.overBudgetCategories[0];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+      <Card className="shadow-none">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <p className="text-sm text-muted-foreground">Total Spent</p>
+          <CreditCardIcon className="size-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <p className="text-2xl font-semibold">
+            {numberFormat(kpis.totalSpent)}
+          </p>
+          <DeltaLine
+            deltaPct={kpis.totalSpentDeltaPct}
+            context="vs previous period"
+          />
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-none">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <p className="text-sm text-muted-foreground">Remaining Budget</p>
+          <WalletIcon className="size-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <p
+            className={cn(
+              'text-2xl font-semibold',
+              kpis.remainingBudget < 0 && 'text-destructive',
+            )}
+          >
+            {numberFormat(kpis.remainingBudget)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            of {numberFormat(kpis.totalBudget)} total budgeted
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-none">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <p className="text-sm text-muted-foreground">Over Budget</p>
+          <TriangleAlertIcon className="size-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <p className="text-2xl font-semibold">
+            {kpis.overBudgetCategories.length}{' '}
+            {kpis.overBudgetCategories.length === 1 ? 'category' : 'categories'}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {worstOverBudget ? (
+              <>
+                <span className="font-medium text-destructive">
+                  +{numberFormat(worstOverBudget.overAmount)}
+                </span>{' '}
+                {worstOverBudget.categoryName} is over
+              </>
+            ) : (
+              'All categories on track'
+            )}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-none">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <p className="text-sm text-muted-foreground">Avg Monthly Spend</p>
+          <CalendarIcon className="size-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <p className="text-2xl font-semibold">
+            {numberFormat(kpis.avgMonthlySpend)}
+          </p>
+          <DeltaLine
+            deltaPct={kpis.avgMonthlySpendDeltaPct}
+            context="vs previous period"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/it/components/dashboard/monthly-overview-chart.tsx
+++ b/src/features/it/components/dashboard/monthly-overview-chart.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Bar, BarChart, CartesianGrid, Legend, XAxis } from 'recharts';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import { type MonthlyOverviewPoint } from '@/features/it/services/dashboard/data';
+import { numberFormat } from '@/lib/helpers/formatters';
+
+const chartConfig = {
+  spent: {
+    label: 'Spent',
+    color: 'var(--chart-1)',
+  },
+  budget: {
+    label: 'Budget',
+    color: 'var(--chart-2)',
+  },
+} satisfies ChartConfig;
+
+export function MonthlyOverviewChart({
+  data,
+}: {
+  data: Array<MonthlyOverviewPoint>;
+}) {
+  return (
+    <Card className="shadow-none">
+      <CardHeader>
+        <CardTitle>Monthly Overview</CardTitle>
+        <CardDescription>Spending vs budget for the selected period</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[320px] w-full">
+          <BarChart data={data} accessibilityLayer>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={value => numberFormat(value as number)}
+                />
+              }
+            />
+            <Legend />
+            <Bar dataKey="spent" radius={4} fill="var(--color-spent)" />
+            <Bar dataKey="budget" radius={4} fill="var(--color-budget)" />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/it/components/dashboard/period-select.tsx
+++ b/src/features/it/components/dashboard/period-select.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useDashboardPeriod } from '@/features/it/hooks/dashboard/use-period';
+import { DASHBOARD_PERIOD_OPTIONS, type DashboardPeriod } from '@/lib/helpers/dates';
+
+export function PeriodSelect() {
+  const [period, setPeriod] = useDashboardPeriod();
+
+  return (
+    <Select
+      value={period}
+      onValueChange={value => setPeriod(value as DashboardPeriod)}
+    >
+      <SelectTrigger
+        aria-label="Select dashboard period"
+        className="w-full sm:w-56"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {DASHBOARD_PERIOD_OPTIONS.map(({ value, label }) => (
+          <SelectItem key={value} value={value}>
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/features/it/components/dashboard/recent-expenses.tsx
+++ b/src/features/it/components/dashboard/recent-expenses.tsx
@@ -1,0 +1,58 @@
+import { format } from 'date-fns';
+import Link from 'next/link';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty';
+import { type RecentExpense } from '@/features/it/services/dashboard/data';
+import { numberFormat } from '@/lib/helpers/formatters';
+
+export function RecentExpenses({
+  expenses,
+}: {
+  expenses: Array<RecentExpense>;
+}) {
+  return (
+    <Card className="shadow-none">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Recent Transactions</CardTitle>
+        <Link
+          href="/it/expenses-budgeting/expenses"
+          className="text-sm text-primary hover:underline"
+        >
+          View all
+        </Link>
+      </CardHeader>
+      <CardContent>
+        {expenses.length === 0 ? (
+          <EmptyState
+            title="No transactions in this period"
+            description="Recorded expenses will show up here."
+            variant="default"
+          />
+        ) : (
+          <ul className="divide-y">
+            {expenses.map(expense => (
+              <li
+                key={expense.id}
+                className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0"
+              >
+                <div className="min-w-0">
+                  <p className="font-medium truncate">{expense.title}</p>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {expense.subCategory} · {expense.category}
+                  </p>
+                </div>
+                <div className="text-right shrink-0">
+                  <p className="font-medium">-{numberFormat(expense.amount)}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {format(new Date(expense.expenseDate), 'MMM d')}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/it/hooks/dashboard/use-period.ts
+++ b/src/features/it/hooks/dashboard/use-period.ts
@@ -1,0 +1,16 @@
+import { parseAsStringEnum, useQueryState } from 'nuqs';
+
+import {
+  DASHBOARD_PERIODS,
+  type DashboardPeriod,
+  DEFAULT_DASHBOARD_PERIOD,
+} from '@/lib/helpers/dates';
+
+export function useDashboardPeriod() {
+  return useQueryState(
+    'period',
+    parseAsStringEnum<DashboardPeriod>([...DASHBOARD_PERIODS]).withDefault(
+      DEFAULT_DASHBOARD_PERIOD,
+    ),
+  );
+}

--- a/src/features/it/services/dashboard/data.ts
+++ b/src/features/it/services/dashboard/data.ts
@@ -1,0 +1,294 @@
+import { and, desc, eq, gte, lt, sql } from 'drizzle-orm';
+
+import db from '@/drizzle/db';
+import {
+  itBudgetLines,
+  itBudgets,
+  itCategories,
+  itExpenses,
+  itSubCategories,
+  vendors,
+} from '@/drizzle/schema';
+import {
+  calculateAverageMonthlySpend,
+  type DashboardPeriod,
+  type DashboardPeriodRange,
+  getFinancialYearMonthsForPeriod,
+} from '@/lib/helpers/dates';
+import { calculatePercentDelta, dateFormat } from '@/lib/helpers/formatters';
+import { requireAnyPermission } from '@/lib/permissions/guards';
+
+export type CategoryRollupRow = {
+  categoryId: string;
+  categoryName: string;
+  budgeted: number;
+  actual: number;
+  /**
+   * Stable position in the canonical (alphabetical) category order, used to
+   * assign a consistent color wherever a category is displayed — even when
+   * a widget re-sorts its own copy of the rows (e.g. by spend amount).
+   */
+  colorIndex: number;
+};
+
+/**
+ * Actual and budgeted totals per top-level category for the given range.
+ * Actual is rolled up directly from itExpenses.categoryId (present on every
+ * expense row); budgeted is rolled up via itSubCategories, since itBudgets
+ * is only ever attached to a sub-category in this schema (subCategoryId is
+ * required), so there is no parent/child budget row to double-count.
+ * Shared by the KPI cards, By Category chart, and Budget Tracker so the
+ * period filter only needs to be applied once per page render.
+ */
+export async function getCategoryRollup(
+  range: DashboardPeriodRange,
+): Promise<Array<CategoryRollupRow>> {
+  await requireAnyPermission(['it:admin', 'it:standard']);
+
+  const from = dateFormat(range.from);
+  const toExclusive = dateFormat(range.toExclusive);
+
+  const [categories, actualRows, budgetedRows] = await Promise.all([
+    db.query.itCategories.findMany({ columns: { id: true, name: true } }),
+    db
+      .select({
+        categoryId: itExpenses.categoryId,
+        total: sql<string>`SUM(${itExpenses.amount})`,
+      })
+      .from(itExpenses)
+      .where(
+        and(
+          gte(itExpenses.expenseDate, from),
+          lt(itExpenses.expenseDate, toExclusive),
+        ),
+      )
+      .groupBy(itExpenses.categoryId),
+    db
+      .select({
+        categoryId: itCategories.id,
+        total: sql<string>`SUM(${itBudgetLines.amount})`,
+      })
+      .from(itBudgetLines)
+      .innerJoin(itBudgets, eq(itBudgets.id, itBudgetLines.budgetId))
+      .innerJoin(
+        itSubCategories,
+        eq(itSubCategories.id, itBudgets.subCategoryId),
+      )
+      .innerJoin(itCategories, eq(itCategories.id, itSubCategories.categoryId))
+      .where(
+        and(
+          eq(itBudgets.financialYearStart, range.financialYearStart),
+          gte(itBudgetLines.monthDate, from),
+          lt(itBudgetLines.monthDate, toExclusive),
+        ),
+      )
+      .groupBy(itCategories.id),
+  ]);
+
+  const actualByCategory = new Map(
+    actualRows.map(row => [row.categoryId, Number(row.total)]),
+  );
+  const budgetedByCategory = new Map(
+    budgetedRows.map(row => [row.categoryId, Number(row.total)]),
+  );
+
+  return categories
+    .map(category => ({
+      categoryId: category.id,
+      categoryName: category.name,
+      budgeted: budgetedByCategory.get(category.id) ?? 0,
+      actual: actualByCategory.get(category.id) ?? 0,
+    }))
+    .sort((a, b) => a.categoryName.localeCompare(b.categoryName))
+    .map((row, index) => ({ ...row, colorIndex: index }));
+}
+
+/** Lightweight total-spent-only query, used for the comparison period. */
+export async function getTotalSpent(
+  range: DashboardPeriodRange,
+): Promise<number> {
+  await requireAnyPermission(['it:admin', 'it:standard']);
+
+  const [row] = await db
+    .select({ total: sql<string>`COALESCE(SUM(${itExpenses.amount}), 0)` })
+    .from(itExpenses)
+    .where(
+      and(
+        gte(itExpenses.expenseDate, dateFormat(range.from)),
+        lt(itExpenses.expenseDate, dateFormat(range.toExclusive)),
+      ),
+    );
+
+  return Number(row?.total ?? 0);
+}
+
+export type MonthlyOverviewPoint = {
+  monthDate: string;
+  label: string;
+  spent: number;
+  budget: number;
+};
+
+/** Spent vs budget per financial-year month covered by the period. */
+export async function getMonthlyOverview(
+  range: DashboardPeriodRange,
+  period: DashboardPeriod,
+  referenceDate: Date = new Date(),
+): Promise<Array<MonthlyOverviewPoint>> {
+  await requireAnyPermission(['it:admin', 'it:standard']);
+
+  const months = getFinancialYearMonthsForPeriod(period, referenceDate);
+  const from = dateFormat(range.from);
+  const toExclusive = dateFormat(range.toExclusive);
+
+  const [spentRows, budgetRows] = await Promise.all([
+    db
+      .select({
+        month: sql<string>`to_char(date_trunc('month', ${itExpenses.expenseDate}::date), 'YYYY-MM-DD')`,
+        total: sql<string>`SUM(${itExpenses.amount})`,
+      })
+      .from(itExpenses)
+      .where(
+        and(
+          gte(itExpenses.expenseDate, from),
+          lt(itExpenses.expenseDate, toExclusive),
+        ),
+      )
+      .groupBy(sql`date_trunc('month', ${itExpenses.expenseDate}::date)`),
+    db
+      .select({
+        month: itBudgetLines.monthDate,
+        total: sql<string>`SUM(${itBudgetLines.amount})`,
+      })
+      .from(itBudgetLines)
+      .innerJoin(itBudgets, eq(itBudgets.id, itBudgetLines.budgetId))
+      .where(
+        and(
+          eq(itBudgets.financialYearStart, range.financialYearStart),
+          gte(itBudgetLines.monthDate, from),
+          lt(itBudgetLines.monthDate, toExclusive),
+        ),
+      )
+      .groupBy(itBudgetLines.monthDate),
+  ]);
+
+  const spentByMonth = new Map(
+    spentRows.map(row => [row.month, Number(row.total)]),
+  );
+  const budgetByMonth = new Map(
+    budgetRows.map(row => [row.month, Number(row.total)]),
+  );
+
+  return months.map(month => {
+    const monthDate = dateFormat(month.date);
+    return {
+      monthDate,
+      label: month.label,
+      spent: spentByMonth.get(monthDate) ?? 0,
+      budget: budgetByMonth.get(monthDate) ?? 0,
+    };
+  });
+}
+
+export type RecentExpense = {
+  id: string;
+  title: string;
+  vendor: string;
+  category: string;
+  subCategory: string;
+  amount: number;
+  expenseDate: string;
+};
+
+export async function getRecentExpenses(
+  range: DashboardPeriodRange,
+  limit = 7,
+): Promise<Array<RecentExpense>> {
+  await requireAnyPermission(['it:admin', 'it:standard']);
+
+  const rows = await db
+    .select({
+      id: itExpenses.id,
+      title: itExpenses.title,
+      vendor: vendors.vendorName,
+      category: itCategories.name,
+      subCategory: itSubCategories.name,
+      amount: itExpenses.amount,
+      expenseDate: itExpenses.expenseDate,
+    })
+    .from(itExpenses)
+    .innerJoin(vendors, eq(vendors.id, itExpenses.vendorId))
+    .innerJoin(itCategories, eq(itCategories.id, itExpenses.categoryId))
+    .innerJoin(
+      itSubCategories,
+      eq(itSubCategories.id, itExpenses.subCategoryId),
+    )
+    .where(
+      and(
+        gte(itExpenses.expenseDate, dateFormat(range.from)),
+        lt(itExpenses.expenseDate, dateFormat(range.toExclusive)),
+      ),
+    )
+    .orderBy(desc(itExpenses.expenseDate), desc(itExpenses.id))
+    .limit(limit);
+
+  return rows.map(row => ({ ...row, amount: Number(row.amount) }));
+}
+
+export type DashboardKpis = {
+  totalSpent: number;
+  totalSpentDeltaPct: number | null;
+  totalBudget: number;
+  remainingBudget: number;
+  overBudgetCategories: Array<{ categoryName: string; overAmount: number }>;
+  avgMonthlySpend: number;
+  avgMonthlySpendDeltaPct: number | null;
+};
+
+/**
+ * Pure computation from already-fetched data — no DB access — so every KPI
+ * derives from the same single category rollup instead of each card running
+ * its own conflicting query.
+ */
+export function buildDashboardKpis(
+  categoryRollup: Array<CategoryRollupRow>,
+  monthsInPeriod: number,
+  comparisonTotalSpent: number,
+  comparisonMonthsInPeriod: number,
+): DashboardKpis {
+  const totalSpent = categoryRollup.reduce((sum, row) => sum + row.actual, 0);
+  const totalBudget = categoryRollup.reduce(
+    (sum, row) => sum + row.budgeted,
+    0,
+  );
+
+  const overBudgetCategories = categoryRollup
+    .filter(row => row.actual > row.budgeted)
+    .map(row => ({
+      categoryName: row.categoryName,
+      overAmount: row.actual - row.budgeted,
+    }))
+    .sort((a, b) => b.overAmount - a.overAmount);
+
+  const avgMonthlySpend = calculateAverageMonthlySpend(
+    totalSpent,
+    monthsInPeriod,
+  );
+  const comparisonAvgMonthlySpend = calculateAverageMonthlySpend(
+    comparisonTotalSpent,
+    comparisonMonthsInPeriod,
+  );
+
+  return {
+    totalSpent,
+    totalSpentDeltaPct: calculatePercentDelta(totalSpent, comparisonTotalSpent),
+    totalBudget,
+    remainingBudget: totalBudget - totalSpent,
+    overBudgetCategories,
+    avgMonthlySpend,
+    avgMonthlySpendDeltaPct: calculatePercentDelta(
+      avgMonthlySpend,
+      comparisonAvgMonthlySpend,
+    ),
+  };
+}

--- a/src/features/it/utils/dashboard/colors.ts
+++ b/src/features/it/utils/dashboard/colors.ts
@@ -1,0 +1,16 @@
+const CATEGORY_COLORS = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+];
+
+/**
+ * Stable color for a category at a given position in a deterministically
+ * sorted list (e.g. alphabetical), so the same category keeps the same
+ * color across the By Category chart and Budget Tracker.
+ */
+export function getCategoryColor(index: number): string {
+  return CATEGORY_COLORS[index % CATEGORY_COLORS.length] as string;
+}

--- a/src/lib/helpers/dates.test.ts
+++ b/src/lib/helpers/dates.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  calculateAverageMonthlySpend,
+  DASHBOARD_PERIOD_OPTIONS,
+  DASHBOARD_PERIODS,
+  DEFAULT_DASHBOARD_PERIOD,
+  getDashboardComparisonPeriodRange,
+  getDashboardPeriodRange,
+  getFinancialYearStart,
+  getMonthsElapsedInFinancialYear,
+} from '@/lib/helpers/dates';
+
+describe('getFinancialYearStart', () => {
+  it('starts the financial year in the same calendar year for May–December', () => {
+    expect(getFinancialYearStart(new Date(2025, 4, 1))).toBe(2025); // May 1
+    expect(getFinancialYearStart(new Date(2025, 7, 15))).toBe(2025); // Aug 15
+    expect(getFinancialYearStart(new Date(2025, 11, 31))).toBe(2025); // Dec 31
+  });
+
+  it('starts the financial year in the previous calendar year for January–April', () => {
+    expect(getFinancialYearStart(new Date(2026, 0, 1))).toBe(2025); // Jan 1
+    expect(getFinancialYearStart(new Date(2026, 2, 15))).toBe(2025); // Mar 15
+    expect(getFinancialYearStart(new Date(2026, 3, 30))).toBe(2025); // Apr 30
+  });
+});
+
+describe('getDashboardPeriodRange — quarter boundaries', () => {
+  // Reference date sits in Q3 (Dec), so the active FY starts in 2025.
+  const reference = new Date(2025, 11, 15);
+
+  it('Q1 covers May 1 through July 31 (exclusive Aug 1)', () => {
+    const range = getDashboardPeriodRange('q1', reference);
+    expect(range.from).toEqual(new Date(2025, 4, 1));
+    expect(range.toExclusive).toEqual(new Date(2025, 7, 1));
+    expect(range.monthsInPeriod).toBe(3);
+  });
+
+  it('Q2 covers August 1 through October 31 (exclusive Nov 1)', () => {
+    const range = getDashboardPeriodRange('q2', reference);
+    expect(range.from).toEqual(new Date(2025, 7, 1));
+    expect(range.toExclusive).toEqual(new Date(2025, 10, 1));
+    expect(range.monthsInPeriod).toBe(3);
+  });
+
+  it('Q3 covers November 1 through January 31, crossing the calendar-year boundary (exclusive Feb 1 of Y+1)', () => {
+    const range = getDashboardPeriodRange('q3', reference);
+    expect(range.from).toEqual(new Date(2025, 10, 1));
+    expect(range.toExclusive).toEqual(new Date(2026, 1, 1));
+    expect(range.from.getFullYear()).toBe(2025);
+    expect(range.toExclusive.getFullYear()).toBe(2026);
+    expect(range.monthsInPeriod).toBe(3);
+  });
+
+  it('Q4 covers February 1 through April 30 of Y+1 (exclusive May 1 of Y+1)', () => {
+    const range = getDashboardPeriodRange('q4', reference);
+    expect(range.from).toEqual(new Date(2026, 1, 1));
+    expect(range.toExclusive).toEqual(new Date(2026, 4, 1));
+    expect(range.monthsInPeriod).toBe(3);
+  });
+
+  it('Previous Year covers May 1, Y-1 through April 30, Y (exclusive May 1, Y)', () => {
+    const range = getDashboardPeriodRange('previous', reference);
+    expect(range.from).toEqual(new Date(2024, 4, 1));
+    expect(range.toExclusive).toEqual(new Date(2025, 4, 1));
+    expect(range.monthsInPeriod).toBe(12);
+    expect(range.financialYearStart).toBe(2024);
+  });
+});
+
+describe('getDashboardPeriodRange — Current Year', () => {
+  it('ends at the day after the reference date when inside the active financial year', () => {
+    const reference = new Date(2025, 11, 15); // Dec 15, 2025
+    const range = getDashboardPeriodRange('current', reference);
+    expect(range.from).toEqual(new Date(2025, 4, 1));
+    expect(range.toExclusive).toEqual(new Date(2025, 11, 16));
+    expect(range.monthsInPeriod).toBe(8); // May..Dec
+  });
+
+  it('never exceeds April 30 of Y+1 (exclusive May 1, Y+1)', () => {
+    const reference = new Date(2026, 3, 30); // Apr 30, 2026 (fyStartYear 2025)
+    const range = getDashboardPeriodRange('current', reference);
+    expect(range.toExclusive.getTime()).toBeLessThanOrEqual(
+      new Date(2026, 4, 1).getTime(),
+    );
+  });
+
+  it('handles a leap-year February reference date correctly', () => {
+    const reference = new Date(2028, 1, 29); // Feb 29, 2028 (leap year)
+    const range = getDashboardPeriodRange('current', reference);
+    // fyStartYear for Feb 2028 is 2027 (Jan-Apr belongs to previous FY start)
+    expect(range.from).toEqual(new Date(2027, 4, 1));
+    expect(range.toExclusive).toEqual(new Date(2028, 2, 1)); // rolls over to Mar 1
+    expect(range.monthsInPeriod).toBe(10); // May..Feb
+  });
+});
+
+describe('getMonthsElapsedInFinancialYear', () => {
+  it('counts May as month 1', () => {
+    expect(getMonthsElapsedInFinancialYear(new Date(2025, 4, 1))).toBe(1);
+  });
+
+  it('counts December as month 8', () => {
+    expect(getMonthsElapsedInFinancialYear(new Date(2025, 11, 1))).toBe(8);
+  });
+
+  it('counts January (next calendar year) as month 9', () => {
+    expect(getMonthsElapsedInFinancialYear(new Date(2026, 0, 1))).toBe(9);
+  });
+
+  it('counts April (next calendar year) as month 12', () => {
+    expect(getMonthsElapsedInFinancialYear(new Date(2026, 3, 30))).toBe(12);
+  });
+});
+
+describe('getDashboardComparisonPeriodRange', () => {
+  it('shifts the same period back exactly one financial year', () => {
+    const reference = new Date(2025, 11, 15);
+    const primary = getDashboardPeriodRange('q3', reference);
+    const comparison = getDashboardComparisonPeriodRange('q3', reference);
+
+    expect(comparison.from).toEqual(new Date(2024, 10, 1));
+    expect(comparison.toExclusive).toEqual(new Date(2025, 1, 1));
+    expect(comparison.financialYearStart).toBe(
+      primary.financialYearStart - 1,
+    );
+  });
+
+  it('keeps the same elapsed-month count for Current Year comparisons', () => {
+    const reference = new Date(2025, 11, 15);
+    const primary = getDashboardPeriodRange('current', reference);
+    const comparison = getDashboardComparisonPeriodRange('current', reference);
+
+    expect(comparison.monthsInPeriod).toBe(primary.monthsInPeriod);
+    expect(comparison.from).toEqual(new Date(2024, 4, 1));
+  });
+});
+
+describe('default dashboard period', () => {
+  it('defaults to Current Year', () => {
+    expect(DEFAULT_DASHBOARD_PERIOD).toBe('current');
+    expect(DASHBOARD_PERIOD_OPTIONS[0]?.value).toBe('current');
+  });
+
+  it('produces a distinct range for every period option', () => {
+    const reference = new Date(2025, 11, 15);
+    const ranges = DASHBOARD_PERIODS.map(period =>
+      getDashboardPeriodRange(period, reference),
+    );
+    const signatures = new Set(
+      ranges.map(range => `${range.from.getTime()}-${range.toExclusive.getTime()}`),
+    );
+    expect(signatures.size).toBe(DASHBOARD_PERIODS.length);
+  });
+});
+
+describe('calculateAverageMonthlySpend', () => {
+  it('divides total spend by the months in a quarter', () => {
+    expect(calculateAverageMonthlySpend(900, 3)).toBe(300);
+  });
+
+  it('divides total spend by 12 for Previous Year', () => {
+    expect(calculateAverageMonthlySpend(2400, 12)).toBe(200);
+  });
+
+  it('divides by the elapsed months for a partial Current Year', () => {
+    const reference = new Date(2025, 11, 15);
+    const months = getMonthsElapsedInFinancialYear(reference); // 8
+    expect(calculateAverageMonthlySpend(1600, months)).toBe(200);
+  });
+
+  it('returns zero when total spend is zero', () => {
+    expect(calculateAverageMonthlySpend(0, 8)).toBe(0);
+  });
+
+  it('returns zero when the month count is zero', () => {
+    expect(calculateAverageMonthlySpend(500, 0)).toBe(0);
+  });
+});

--- a/src/lib/helpers/dates.ts
+++ b/src/lib/helpers/dates.ts
@@ -75,3 +75,189 @@ export function getFinancialYearOptions(
     };
   }).reverse();
 }
+
+export const DASHBOARD_PERIODS = [
+  'current',
+  'q1',
+  'q2',
+  'q3',
+  'q4',
+  'previous',
+] as const;
+
+export type DashboardPeriod = (typeof DASHBOARD_PERIODS)[number];
+
+export const DEFAULT_DASHBOARD_PERIOD: DashboardPeriod = 'current';
+
+export const DASHBOARD_PERIOD_LABELS: Record<DashboardPeriod, string> = {
+  current: 'Current Year',
+  q1: 'Q1 (May–July)',
+  q2: 'Q2 (Aug–Oct)',
+  q3: 'Q3 (Nov–Jan)',
+  q4: 'Q4 (Feb–Apr)',
+  previous: 'Previous Year',
+};
+
+export const DASHBOARD_PERIOD_OPTIONS: Array<Option> = DASHBOARD_PERIODS.map(
+  period => ({
+    value: period,
+    label: DASHBOARD_PERIOD_LABELS[period],
+  })
+);
+
+export function isDashboardPeriod(value: string): value is DashboardPeriod {
+  return (DASHBOARD_PERIODS as ReadonlyArray<string>).includes(value);
+}
+
+/**
+ * total actual expenses in the selected range ÷ number of financial-year
+ * months represented by that range. Zero when either side is zero.
+ */
+export function calculateAverageMonthlySpend(
+  totalSpent: number,
+  monthsInPeriod: number
+): number {
+  if (!monthsInPeriod || !totalSpent) return 0;
+  return totalSpent / monthsInPeriod;
+}
+
+/**
+ * Number of financial-year calendar months reached from May through the
+ * month of `referenceDate`, inclusive of the current partial month.
+ */
+export function getMonthsElapsedInFinancialYear(
+  referenceDate: Date = new Date()
+): number {
+  const month = referenceDate.getMonth();
+  return ((month - 4 + 12) % 12) + 1;
+}
+
+export type DashboardPeriodRange = {
+  from: Date;
+  toExclusive: Date;
+  monthsInPeriod: number;
+  financialYearStart: number;
+};
+
+/**
+ * Half-open [from, toExclusive) date range for a dashboard period, plus the
+ * number of financial-year months it represents (used for average-monthly
+ * calculations) and the it_budgets.financialYearStart it belongs to.
+ */
+export function getDashboardPeriodRange(
+  period: DashboardPeriod,
+  referenceDate: Date = new Date()
+): DashboardPeriodRange {
+  const fyStartYear = getFinancialYearStart(referenceDate);
+
+  switch (period) {
+    case 'current': {
+      const from = new Date(fyStartYear, 4, 1);
+      const fyEndExclusive = new Date(fyStartYear + 1, 4, 1);
+      const dayAfterReference = new Date(
+        referenceDate.getFullYear(),
+        referenceDate.getMonth(),
+        referenceDate.getDate() + 1
+      );
+
+      return {
+        from,
+        toExclusive:
+          dayAfterReference < fyEndExclusive
+            ? dayAfterReference
+            : fyEndExclusive,
+        monthsInPeriod: getMonthsElapsedInFinancialYear(referenceDate),
+        financialYearStart: fyStartYear,
+      };
+    }
+    case 'q1':
+      return {
+        from: new Date(fyStartYear, 4, 1),
+        toExclusive: new Date(fyStartYear, 7, 1),
+        monthsInPeriod: 3,
+        financialYearStart: fyStartYear,
+      };
+    case 'q2':
+      return {
+        from: new Date(fyStartYear, 7, 1),
+        toExclusive: new Date(fyStartYear, 10, 1),
+        monthsInPeriod: 3,
+        financialYearStart: fyStartYear,
+      };
+    case 'q3':
+      return {
+        from: new Date(fyStartYear, 10, 1),
+        toExclusive: new Date(fyStartYear + 1, 1, 1),
+        monthsInPeriod: 3,
+        financialYearStart: fyStartYear,
+      };
+    case 'q4':
+      return {
+        from: new Date(fyStartYear + 1, 1, 1),
+        toExclusive: new Date(fyStartYear + 1, 4, 1),
+        monthsInPeriod: 3,
+        financialYearStart: fyStartYear,
+      };
+    case 'previous':
+      return {
+        from: new Date(fyStartYear - 1, 4, 1),
+        toExclusive: new Date(fyStartYear, 4, 1),
+        monthsInPeriod: 12,
+        financialYearStart: fyStartYear - 1,
+      };
+  }
+}
+
+/**
+ * The same period definition, shifted back exactly one financial year —
+ * used as the comparison baseline for "vs previous period" deltas. Reuses
+ * `getDashboardPeriodRange` by shifting the reference date back a year
+ * rather than duplicating the range rules.
+ */
+export function getDashboardComparisonPeriodRange(
+  period: DashboardPeriod,
+  referenceDate: Date = new Date()
+): DashboardPeriodRange {
+  const oneYearEarlier = new Date(
+    referenceDate.getFullYear() - 1,
+    referenceDate.getMonth(),
+    referenceDate.getDate()
+  );
+
+  return getDashboardPeriodRange(period, oneYearEarlier);
+}
+
+const PERIOD_MONTH_INDEX_RANGES: Record<
+  'q1' | 'q2' | 'q3' | 'q4',
+  [number, number]
+> = {
+  q1: [0, 3],
+  q2: [3, 6],
+  q3: [6, 9],
+  q4: [9, 12],
+};
+
+/**
+ * The financial-year month list (from `getFinancialYearMonths`) sliced down
+ * to whichever months the given period actually covers, so chart callers
+ * never need their own month-range logic.
+ */
+export function getFinancialYearMonthsForPeriod(
+  period: DashboardPeriod,
+  referenceDate: Date = new Date()
+): Array<{ date: Date; label: string }> {
+  const fyStartYear = getFinancialYearStart(referenceDate);
+
+  if (period === 'previous') {
+    return getFinancialYearMonths(fyStartYear - 1);
+  }
+
+  const months = getFinancialYearMonths(fyStartYear);
+
+  if (period === 'current') {
+    return months.slice(0, getMonthsElapsedInFinancialYear(referenceDate));
+  }
+
+  const [start, end] = PERIOD_MONTH_INDEX_RANGES[period];
+  return months.slice(start, end);
+}

--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -50,6 +50,14 @@ export function numberFormat(
   }).format(Number(number));
 }
 
+export function calculatePercentDelta(
+  current: number,
+  previous: number
+): number | null {
+  if (previous === 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
 export const compactNumberFormatter = (value: string | number) => {
   return new Intl.NumberFormat('en-KE', {
     notation: 'compact',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Replace the IT Expenses & Budgeting placeholder page with a full dashboard (KPI cards, Monthly Overview and By Category charts, Recent Transactions, and a category-level Budget Tracker), built against a Banani design reference and wired to real data via `it_expenses` / `it_budgets` / `it_budget_lines`.
- Add a single period dropdown (Current Year, Q1–Q4, Previous Year) as the one authoritative date range for the whole page — every card, chart, and list derives from the same server-computed range, so nothing can drift out of sync.
- Add `getDashboardPeriodRange`/`getDashboardComparisonPeriodRange`/`getMonthsElapsedInFinancialYear`/`calculateAverageMonthlySpend` to `src/lib/helpers/dates.ts`, extending the existing May–April financial-year convention rather than introducing a second one.
- Introduce the project's first test setup (`vitest`) and cover the new date-range/period logic with 23 fixed-date unit tests (FY detection, exact Q1–Q4 boundaries, Q3 crossing the calendar year, Previous Year, Current-Year-ends-today, leap-year Feb, default period, and Avg Monthly Spend for every period shape).

## Details

- **Category rollup** (`src/features/it/services/dashboard/data.ts`): actuals are grouped directly off `itExpenses.categoryId`; budgets roll up via `itSubCategories → itCategories` since `itBudgets.subCategoryId` is required in this schema (no parent+child budget row can ever exist, so there's no double-counting to guard against). One rollup query is shared by the KPIs, By Category chart, and Budget Tracker instead of each widget querying separately.
- **Budget Tracker** intentionally shows category rows only — no sub-category rows/expansion, even though the Banani reference includes them.
- **Avg Daily Spend** → **Avg Monthly Spend**: `total actual spend ÷ elapsed financial-year months` (3 for quarters, 12 for Previous Year, elapsed-months-including-partial for Current Year); returns 0 on a zero denominator or zero spend.
- **"vs previous period" deltas** on Total Spent / Avg Monthly Spend compare against the same period shifted back exactly one financial year (documented assumption — the spec didn't define a comparison rule for FY-quarter periods).
- All queries use half-open `[from, toExclusive)` ranges to avoid time-of-day boundary bugs, are parallelized with `Promise.all`, and are permission-gated (`it:admin` / `it:standard`).
- Loading skeleton preserves the dashboard's layout; error state reuses the existing `ErrorFallback`/`ErrorBoundary` pattern with a retry button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an IT Expenses & Budgeting dashboard with selectable reporting periods.
  * Added KPI cards for spending, budgets, over-budget categories, and monthly averages.
  * Added monthly spending charts, category breakdowns, budget progress, and recent transactions.
  * Added an “Add Expense” action and streamlined dashboard navigation.
  * Added loading states, empty states, and permission-protected dashboard data.

* **Tests**
  * Added automated coverage for financial-year periods, comparisons, date ranges, and spend calculations.
  * Added a test command for running the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->