### PR TITLE
fix: use getCurrentUserOrNull in API routes instead of getCurrentUser

### DIFF
--- a/src/app/api/orders/[orderId]/route.ts
+++ b/src/app/api/orders/[orderId]/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import db from '@/drizzle/db';
-import { getCurrentUser } from '@/lib/session';
+import { getCurrentUserOrNull } from '@/lib/session';
 
 export async function GET(
   _req: NextRequest,
@@ -11,7 +11,7 @@ export async function GET(
 ) {
   const { orderId } = await params;
   try {
-    const user = await getCurrentUser();
+    const user = await getCurrentUserOrNull();
     if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { getSelectableProducts } from '@/features/procurement/services/material-requisitions/data';
-import { getCurrentUser } from '@/lib/session';
+import { getCurrentUserOrNull } from '@/lib/session';
 
 export async function GET() {
-  const user = await getCurrentUser();
+  const user = await getCurrentUserOrNull();
 
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { getSelectableProjects } from '@/features/procurement/services/material-requisitions/data';
-import { getCurrentUser } from '@/lib/session';
+import { getCurrentUserOrNull } from '@/lib/session';
 
 export async function GET() {
-  const user = await getCurrentUser();
+  const user = await getCurrentUserOrNull();
 
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/security/password-verify/route.ts
+++ b/src/app/api/security/password-verify/route.ts
@@ -5,14 +5,17 @@ import { NextResponse } from 'next/server';
 import z from 'zod';
 
 import db from '@/drizzle/db';
-import { getCurrentUser } from '@/lib/session';
+import { getCurrentUserOrNull } from '@/lib/session';
 
 const bodySchema = z.object({
   currentPassword: z.string().min(1),
 });
 
 export async function POST(req: NextRequest) {
-  const user = await getCurrentUser();
+  const user = await getCurrentUserOrNull();
+  if (!user)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
   const body = await req.json();
 
   try {

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { getSelectableServices } from '@/features/procurement/services/material-requisitions/data';
-import { getCurrentUser } from '@/lib/session';
+import { getCurrentUserOrNull } from '@/lib/session';
 
 export async function GET() {
-  const user = await getCurrentUser();
+  const user = await getCurrentUserOrNull();
 
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { getActiveVendors } from '@/features/procurement/services/purchase-orders/data';
-import { getCurrentUser } from '@/lib/session';
+import { getCurrentUserOrNull } from '@/lib/session';
 
 export async function GET() {
-  const user = await getCurrentUser();
+  const user = await getCurrentUserOrNull();
 
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });


### PR DESCRIPTION
## Summary
- `getCurrentUser()` redirects to `/login` when unauthenticated, which throws inside a route handler instead of returning JSON — either silently swallowed by a `try/catch` into a misleading 500, or surfaced as an HTML redirect to a JSON API consumer.
- Six API routes (`vendors`, `services`, `projects`, `products`, `orders/[orderId]`, `security/password-verify`) called `getCurrentUser()` and either had a dead `if (!user)` 401 check that could never run, or (in `password-verify`'s case) no check at all.
- Swapped all six to the non-throwing `getCurrentUserOrNull()`, making the existing 401 checks live, and added the missing check to `password-verify`.
- `notifications/route.ts` and `notifications/recent/route.ts` already used the correct pattern and were left untouched — they were the reference for this fix.

## Test plan
- [x] `pnpm lint:check` on touched files
- [x] `pnpm test` (94 tests passing)
- [x] `npx tsc --noEmit` (no new errors; one pre-existing unrelated failure in `next-link-prefetch.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication handling across orders, products, projects, password verification, services, and vendors endpoints.
  - Unauthenticated requests now consistently receive a clear **401 Unauthorized** response.
  - Existing data retrieval and server-error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->