### PR TITLE
chunk store product deactivation inngest steps

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -1,11 +1,11 @@
-import { serve } from "inngest/next";
+import { serve } from 'inngest/next';
 
-import { inngest } from "@/inngest/client";
-import { runStoreProductDeactivation } from "@/inngest/functions/store-product-deactivation";
-import { sendUserNewPassword } from "@/inngest/functions/users";
+import { inngest } from '@/inngest/client';
+import { runStoreProductDeactivation } from '@/inngest/functions/store-product-deactivation';
+import { sendUserNewPassword } from '@/inngest/functions/users';
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [sendUserNewPassword, runStoreProductDeactivation],
-  streaming: "allow",
+  streaming: 'force',
 });

--- a/src/features/store/services/product-deactivation/actions-orchestration.test.ts
+++ b/src/features/store/services/product-deactivation/actions-orchestration.test.ts
@@ -3,31 +3,42 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   execute,
   findFirst,
+  insert,
   transaction,
   getEligibleCandidates,
   revalidateProductDeactivation,
+  sumProductBalanceAcrossStores,
+  update,
 } = vi.hoisted(() => {
   const execute = vi.fn();
   const findFirst = vi.fn();
+  const insert = vi.fn();
   const transaction = vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
     callback({
       execute,
+      insert,
       query: {
         productDeactivationBatches: {
           findFirst,
         },
       },
+      update,
     }),
   );
   const getEligibleCandidates = vi.fn();
   const revalidateProductDeactivation = vi.fn();
+  const sumProductBalanceAcrossStores = vi.fn();
+  const update = vi.fn();
 
   return {
     execute,
     findFirst,
+    insert,
     transaction,
     getEligibleCandidates,
     revalidateProductDeactivation,
+    sumProductBalanceAcrossStores,
+    update,
   };
 });
 
@@ -42,7 +53,7 @@ vi.mock('@/features/store/services/product-deactivation/eligibility', () => ({
 }));
 
 vi.mock('@/features/store/services/product-deactivation/balance', () => ({
-  sumProductBalanceAcrossStores: vi.fn(),
+  sumProductBalanceAcrossStores,
 }));
 
 vi.mock('@/features/store/utils/cache', () => ({
@@ -61,15 +72,21 @@ vi.mock('@/lib/permissions/service', () => ({
   ADMIN_USER_TYPES: new Set(),
 }));
 
-import { deactivateAndLogStaleProducts } from '@/features/store/services/product-deactivation/actions';
+import {
+  deactivateAndLogStaleProducts,
+  deactivateNextStaleProductsChunk,
+} from '@/features/store/services/product-deactivation/actions';
 
 describe('deactivateAndLogStaleProducts', () => {
   beforeEach(() => {
     execute.mockReset();
     findFirst.mockReset();
+    insert.mockReset();
     transaction.mockClear();
     getEligibleCandidates.mockReset();
     revalidateProductDeactivation.mockReset();
+    sumProductBalanceAcrossStores.mockReset();
+    update.mockReset();
   });
 
   it('recovers an existing batch for the same trigger request id before rescanning candidates', async () => {
@@ -89,5 +106,81 @@ describe('deactivateAndLogStaleProducts', () => {
     });
     expect(getEligibleCandidates).not.toHaveBeenCalled();
     expect(revalidateProductDeactivation).toHaveBeenCalledWith('batch-1');
+  });
+
+  it('processes one bounded chunk and records progress in the batch', async () => {
+    let insertCallCount = 0;
+    let updateCallCount = 0;
+
+    findFirst.mockResolvedValueOnce(null);
+    getEligibleCandidates.mockResolvedValueOnce([
+      {
+        productId: 'product-1',
+        createdOn: null,
+        lastUsedDate: new Date('2024-01-01'),
+        lastUsedSource: 'stock_movements',
+      },
+      {
+        productId: 'product-2',
+        createdOn: null,
+        lastUsedDate: new Date('2024-01-02'),
+        lastUsedSource: 'mrq',
+      },
+      {
+        productId: 'product-3',
+        createdOn: null,
+        lastUsedDate: new Date('2024-01-03'),
+        lastUsedSource: 'orders',
+      },
+    ]);
+    sumProductBalanceAcrossStores.mockResolvedValue(0);
+
+    insert.mockImplementation(() => ({
+      values: vi.fn(() => {
+        insertCallCount += 1;
+
+        if (insertCallCount === 1) {
+          return {
+            returning: vi.fn().mockResolvedValue([{ id: 'batch-new' }]),
+          };
+        }
+
+        return Promise.resolve();
+      }),
+    }));
+
+    update.mockImplementation(() => {
+      updateCallCount += 1;
+
+      if (updateCallCount === 1) {
+        return {
+          set: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(undefined),
+          })),
+        };
+      }
+
+      return {
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([{ totalCount: 2 }]),
+          })),
+        })),
+      };
+    });
+
+    const result = await deactivateNextStaleProductsChunk(
+      2,
+      new Date('2026-08-04T00:00:00.000Z'),
+      '11111111-1111-1111-1111-111111111111',
+    );
+
+    expect(result).toEqual({
+      batchId: 'batch-new',
+      processedCount: 2,
+      totalCount: 2,
+    });
+    expect(sumProductBalanceAcrossStores).toHaveBeenCalledTimes(2);
+    expect(revalidateProductDeactivation).toHaveBeenCalledWith('batch-new');
   });
 });

--- a/src/features/store/services/product-deactivation/actions.ts
+++ b/src/features/store/services/product-deactivation/actions.ts
@@ -45,6 +45,11 @@ interface ProductDeactivationBatchResult {
   totalCount: number;
 }
 
+export interface ProductDeactivationChunkResult
+  extends ProductDeactivationBatchResult {
+  processedCount: number;
+}
+
 export async function findDeactivationBatchByTriggerRequestId(
   triggerRequestId: string,
   client: Pick<typeof db, 'query'>,
@@ -133,6 +138,102 @@ export async function deactivateAndLogStaleProducts(
 
   if (!result) {
     return null;
+  }
+
+  revalidateProductDeactivation(result.batchId);
+
+  return result;
+}
+
+export async function deactivateNextStaleProductsChunk(
+  limit: number,
+  asOf: Date = new Date(),
+  triggerRequestId?: string,
+): Promise<ProductDeactivationChunkResult | null> {
+  const result = await db.transaction(async tx => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(${PRODUCT_DEACTIVATION_ADVISORY_LOCK})`,
+    );
+
+    let batch = triggerRequestId
+      ? await findDeactivationBatchByTriggerRequestId(triggerRequestId, tx)
+      : null;
+
+    const candidates = await getEligibleCandidates(
+      PRODUCT_DEACTIVATION_THRESHOLD_DAYS,
+      asOf,
+      tx,
+    );
+
+    if (candidates.length === 0) {
+      if (!batch) {
+        return null;
+      }
+
+      return {
+        batchId: batch.batchId,
+        processedCount: 0,
+        totalCount: batch.totalCount,
+      };
+    }
+
+    if (!batch) {
+      const [{ id }] = await tx
+        .insert(productDeactivationBatches)
+        .values({
+          thresholdDays: PRODUCT_DEACTIVATION_THRESHOLD_DAYS,
+          totalCount: 0,
+          triggerRequestId: triggerRequestId ?? null,
+        })
+        .returning({ id: productDeactivationBatches.id });
+
+      batch = {
+        batchId: id,
+        totalCount: 0,
+      };
+    }
+
+    const chunk = candidates.slice(0, limit);
+
+    await tx
+      .update(products)
+      .set({ active: false })
+      .where(
+        inArray(
+          products.id,
+          chunk.map(candidate => candidate.productId),
+        ),
+      );
+
+    for (const candidate of chunk) {
+      const balance = await sumProductBalanceAcrossStores(
+        candidate.productId,
+        asOf,
+      );
+
+      await tx.insert(productDeactivationItems).values({
+        batchId: batch.batchId,
+        ...buildDeactivationItemRow(candidate, balance),
+      });
+    }
+
+    const [updatedBatch] = await tx
+      .update(productDeactivationBatches)
+      .set({
+        totalCount: sql`${productDeactivationBatches.totalCount} + ${chunk.length}`,
+      })
+      .where(eq(productDeactivationBatches.id, batch.batchId))
+      .returning({ totalCount: productDeactivationBatches.totalCount });
+
+    return {
+      batchId: batch.batchId,
+      processedCount: chunk.length,
+      totalCount: updatedBatch.totalCount,
+    };
+  });
+
+  if (!result || result.processedCount === 0) {
+    return result;
   }
 
   revalidateProductDeactivation(result.batchId);

--- a/src/inngest/functions/store-product-deactivation.ts
+++ b/src/inngest/functions/store-product-deactivation.ts
@@ -1,8 +1,11 @@
 import {
-  deactivateAndLogStaleProducts,
+  deactivateNextStaleProductsChunk,
   notifyStoreAdminsOfDeactivation,
 } from '@/features/store/services/product-deactivation/actions';
 import { inngest } from '@/inngest/client';
+
+const PRODUCT_DEACTIVATION_CHUNK_SIZE = 25;
+const MAX_PRODUCT_DEACTIVATION_CHUNKS = 400;
 
 export const runStoreProductDeactivation = inngest.createFunction(
   { id: 'run-store-product-deactivation', retries: 2 },
@@ -17,20 +20,74 @@ export const runStoreProductDeactivation = inngest.createFunction(
       triggeredAt,
     });
 
-    const batch = await step.run('deactivate-and-log-stale-products', async () => {
-      const result = await deactivateAndLogStaleProducts(undefined, requestId);
+    await step.run('start-store-product-deactivation-job', async () => {
+      const startedAt = new Date().toISOString();
 
-      console.info('Finished deactivation batch step', {
+      console.info('Checkpointed store product deactivation start', {
         eventId: event.id,
         requestId,
-        batchId: result?.batchId ?? null,
-        totalCount: result?.totalCount ?? 0,
+        source,
+        triggeredAt,
+        startedAt,
       });
 
-      return result;
+      return {
+        requestId,
+        source,
+        triggeredAt,
+        startedAt,
+      };
     });
 
-    if (!batch) {
+    let batchId: string | null = null;
+    let totalCount = 0;
+
+    for (
+      let chunkIndex = 0;
+      chunkIndex < MAX_PRODUCT_DEACTIVATION_CHUNKS;
+      chunkIndex += 1
+    ) {
+      const chunk = await step.run(
+        `deactivate-stale-products-chunk-${chunkIndex + 1}`,
+        async () => {
+          const result = await deactivateNextStaleProductsChunk(
+            PRODUCT_DEACTIVATION_CHUNK_SIZE,
+            undefined,
+            requestId,
+          );
+
+          console.info('Finished deactivation chunk step', {
+            eventId: event.id,
+            requestId,
+            chunkNumber: chunkIndex + 1,
+            batchId: result?.batchId ?? null,
+            processedCount: result?.processedCount ?? 0,
+            totalCount: result?.totalCount ?? 0,
+          });
+
+          return result;
+        },
+      );
+
+      if (!chunk || chunk.processedCount === 0) {
+        break;
+      }
+
+      batchId = chunk.batchId;
+      totalCount = chunk.totalCount;
+
+      if (chunk.processedCount < PRODUCT_DEACTIVATION_CHUNK_SIZE) {
+        break;
+      }
+
+      if (chunkIndex === MAX_PRODUCT_DEACTIVATION_CHUNKS - 1) {
+        throw new Error(
+          'Store product deactivation exceeded the maximum chunk count for a single run.',
+        );
+      }
+    }
+
+    if (!batchId || totalCount === 0) {
       console.info('No stale products found for deactivation', {
         eventId: event.id,
         requestId,
@@ -48,15 +105,15 @@ export const runStoreProductDeactivation = inngest.createFunction(
       'notify-store-admins-of-deactivation',
       async () => {
         const result = await notifyStoreAdminsOfDeactivation(
-          batch.batchId,
-          batch.totalCount,
+          batchId,
+          totalCount,
         );
 
         console.info('Finished store admin notification step', {
           eventId: event.id,
           requestId,
-          batchId: batch.batchId,
-          totalCount: batch.totalCount,
+          batchId,
+          totalCount,
           notifiedCount: result.notifiedCount,
         });
 
@@ -65,8 +122,8 @@ export const runStoreProductDeactivation = inngest.createFunction(
     );
 
     return {
-      batchId: batch.batchId,
-      totalCount: batch.totalCount,
+      batchId,
+      totalCount,
       notifiedCount: notificationResult.notifiedCount,
       requestId,
     };


### PR DESCRIPTION
## Summary
- force streaming on the Inngest Next.js handler so Vercel can stream step checkpoints back to Inngest
- split store product deactivation into a bootstrap step plus bounded chunk steps instead of one long first step
- keep the batch retry-safe with the existing trigger request id recovery and add orchestration coverage for chunk progress

## Root Cause
The cron endpoint was already enqueueing correctly, but the Inngest execution path still did too much work inside the first `step.run()`. That left `/api/inngest` waiting on one long serverless invocation, which can hit Vercel `FUNCTION_INVOCATION_TIMEOUT` before Inngest receives any step output. In this SDK version, `streaming: "allow"` also depends on platform detection that does not enable Node-on-Vercel streaming here, so the handler could still run without streaming.

## Validation
- `pnpm test`
- `pnpm test src/features/store/services/product-deactivation/actions-orchestration.test.ts`
- `pnpm lint:check src/app/api/inngest/route.ts src/features/store/services/product-deactivation/actions.ts src/features/store/services/product-deactivation/actions-orchestration.test.ts src/inngest/functions/store-product-deactivation.ts`

## Notes
- `pnpm build` was started but did not finish emitting output in the harness before it was stopped.
- ESLint still reports one unrelated pre-existing warning in `src/features/procurement/services/purchase-orders/data.ts`.
